### PR TITLE
Add sock_accept to default import functions

### DIFF
--- a/src/abi.ts
+++ b/src/abi.ts
@@ -82,6 +82,7 @@ export class WASIAbi {
 
         "sched_yield",
 
+        "sock_accept",
         "sock_recv",
         "sock_send",
         "sock_shutdown",


### PR DESCRIPTION
Missing for WASI preview1

https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-sock_acceptfd-fd-flags-fdflags---resultfd-errno