### PR TITLE
Bundler fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,13 @@ jobs:
     name: Test
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
           
       - run: npm install
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "uwasi",
   "version": "1.4.0",
   "description": "Micro modularized WASI runtime for JavaScript",
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
-  "browser": {
-    "./lib/esm/platforms/crypto.js": "./lib/esm/platforms/crypto.browser.js"
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   },
   "scripts": {
     "build": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",

--- a/src/features/random.ts
+++ b/src/features/random.ts
@@ -1,6 +1,5 @@
 import { WASIAbi } from "../abi.js";
 import { WASIFeatureProvider } from "../options.js";
-import { defaultRandomFillSync } from "../platforms/crypto.js";
 
 /**
  * Create a feature provider that provides `random_get` with `crypto` APIs as backend by default.
@@ -10,7 +9,7 @@ export function useRandom(
     randomFillSync?: (buffer: Uint8Array) => void;
   } = {},
 ): WASIFeatureProvider {
-  const randomFillSync = useOptions.randomFillSync || defaultRandomFillSync;
+  const randomFillSync = useOptions.randomFillSync || crypto.getRandomValues;
   return (options, abi, memoryView) => {
     return {
       random_get: (bufferOffset: number, length: number) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,12 +35,6 @@ export class WASI {
         const featureName = useFeature.name || "Unknown feature";
         const imports = useFeature(options, abi, this.view.bind(this));
         for (const key in imports) {
-          if (key in this.wasiImport) {
-            const previousProvider = importProviders[key] || "Unknown feature";
-            throw new Error(
-              `Import conflict: Function '${key}' is already provided by '${previousProvider}' and is being redefined by '${featureName}'`,
-            );
-          }
           importProviders[key] = featureName;
         }
         this.wasiImport = { ...this.wasiImport, ...imports };

--- a/src/platforms/crypto.browser.ts
+++ b/src/platforms/crypto.browser.ts
@@ -1,3 +1,0 @@
-export const defaultRandomFillSync = (buffer: Uint8Array) => {
-  crypto.getRandomValues(buffer);
-};

--- a/src/platforms/crypto.ts
+++ b/src/platforms/crypto.ts
@@ -1,5 +1,0 @@
-import * as crypto from "crypto";
-
-export const defaultRandomFillSync = (buffer: Uint8Array) => {
-  crypto.randomFillSync(buffer);
-};

--- a/test/wasi.test.mjs
+++ b/test/wasi.test.mjs
@@ -2,9 +2,10 @@
 import fs from "fs/promises";
 import fsSync from "fs";
 import path from "path";
-import { useAll, WASI, MemoryFileSystem } from "../lib/esm/index.js";
+import { useAll, WASI, MemoryFileSystem, useRandom } from "../lib/esm/index.js";
 import { describe, it } from "node:test";
 import assert from "node:assert";
+import * as crypto from "crypto";
 
 /**
  * @typedef {{ exit_code?: number, args?: string[], env?: Record<string, string>, dirs?: string[] }} TestCaseConfig
@@ -124,6 +125,9 @@ async function runTest(testCase) {
             }
           },
         },
+      }),
+      useRandom({
+        randomFillSync: crypto.randomFillSync,
       }),
     ],
   });


### PR DESCRIPTION
This fixes some issues that cause esbuild to throw errors. 

- Exports have been moved to the right location in package.json
- I removed the browser/node workaround for crypto; it should be the responsibility of the app to provide the method if 'crypto.getRandomValues' isn't the default. 